### PR TITLE
fix cannot read property 'scrollTop' of undefined.

### DIFF
--- a/book/book-summary-scroll-position-saver.js
+++ b/book/book-summary-scroll-position-saver.js
@@ -6,6 +6,9 @@ require(['gitbook', 'jQuery'], function (gitbook, $) {
 	var $summary;
 
 	bindChangePushState(function() {
+		if (!$summary) {
+			return;
+		}
 		window.sessionStorage.setItem(KEY_SCROLL_POSITION, $summary.scrollTop())
 	});
 


### PR DESCRIPTION
I got a error.

> book-summary-scroll-position-saver.js:9 Uncaught TypeError: Cannot read property 'scrollTop' of undefined
> 
> $ gitbook --version
> CLI version: 2.3.0
> GitBook version: 3.2.0
